### PR TITLE
Fixup mac 10.13 binary symlinks.

### DIFF
--- a/build-support/bin/go/mac/10.13/1.7.6/go.tar.gz
+++ b/build-support/bin/go/mac/10.13/1.7.6/go.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/go/mac/10.12/1.7.6/go.tar.gz
+../../10.12/1.7.6/go.tar.gz

--- a/build-support/bin/go/mac/10.13/1.8.1/go.tar.gz
+++ b/build-support/bin/go/mac/10.13/1.8.1/go.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/go/mac/10.12/1.8.1/go.tar.gz
+../../10.12/1.8.1/go.tar.gz

--- a/build-support/bin/go/mac/10.13/1.8.2/go.tar.gz
+++ b/build-support/bin/go/mac/10.13/1.8.2/go.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/go/mac/10.12/1.8.2/go.tar.gz
+../../10.12/1.8.2/go.tar.gz

--- a/build-support/bin/go/mac/10.13/1.8.3/go.tar.gz
+++ b/build-support/bin/go/mac/10.13/1.8.3/go.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/go/mac/10.12/1.8.3/go.tar.gz
+../../10.12/1.8.3/go.tar.gz

--- a/build-support/bin/node/mac/10.13/v0.12.7/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v0.12.7/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v0.12.7/node.tar.gz
+../../10.12/v0.12.7/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v4.0.0/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v4.0.0/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v4.0.0/node.tar.gz
+../../10.12/v4.0.0/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v4.2.4/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v4.2.4/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v4.2.4/node.tar.gz
+../../10.12/v4.2.4/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v5.5.0/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v5.5.0/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v5.5.0/node.tar.gz
+../../10.12/v5.5.0/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v6.10.2/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v6.10.2/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v6.10.2/node.tar.gz
+../../10.12/v6.10.2/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v6.11.1/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v6.11.1/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v6.11.1/node.tar.gz
+../../10.12/v6.11.1/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v6.2.0/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v6.2.0/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v6.2.0/node.tar.gz
+../../10.12/v6.2.0/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v6.9.1/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v6.9.1/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v6.9.1/node.tar.gz
+../../10.12/v6.9.1/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v6.9.5/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v6.9.5/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v6.9.5/node.tar.gz
+../../10.12/v6.9.5/node.tar.gz

--- a/build-support/bin/node/mac/10.13/v8.2.1/node.tar.gz
+++ b/build-support/bin/node/mac/10.13/v8.2.1/node.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/node/mac/10.12/v8.2.1/node.tar.gz
+../../10.12/v8.2.1/node.tar.gz

--- a/build-support/bin/protobuf/mac/10.13/2.4.1/protoc
+++ b/build-support/bin/protobuf/mac/10.13/2.4.1/protoc
@@ -1,1 +1,1 @@
-build-support/bin/protobuf/mac/10.12/2.4.1/protoc
+../../10.12/2.4.1/protoc

--- a/build-support/bin/protobuf/mac/10.13/2.5.0/protoc
+++ b/build-support/bin/protobuf/mac/10.13/2.5.0/protoc
@@ -1,1 +1,1 @@
-build-support/bin/protobuf/mac/10.12/2.5.0/protoc
+../../10.12/2.5.0/protoc

--- a/build-support/bin/protobuf/mac/10.13/2.6.1/protoc
+++ b/build-support/bin/protobuf/mac/10.13/2.6.1/protoc
@@ -1,1 +1,1 @@
-build-support/bin/protobuf/mac/10.12/2.6.1/protoc
+../../10.12/2.6.1/protoc

--- a/build-support/bin/ragel/mac/10.13/6.9/ragel
+++ b/build-support/bin/ragel/mac/10.13/6.9/ragel
@@ -1,1 +1,1 @@
-build-support/bin/ragel/mac/10.12/6.9/ragel
+../../10.12/6.9/ragel

--- a/build-support/bin/stack/mac/10.13/0.1.6.0/stack.tar.gz
+++ b/build-support/bin/stack/mac/10.13/0.1.6.0/stack.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/stack/mac/10.12/0.1.6.0/stack.tar.gz
+../../10.12/0.1.6.0/stack.tar.gz

--- a/build-support/bin/thrift/mac/10.13/0.5.0-finagle/thrift
+++ b/build-support/bin/thrift/mac/10.13/0.5.0-finagle/thrift
@@ -1,1 +1,1 @@
-build-support/bin/thrift/mac/10.12/0.5.0-finagle/thrift
+../../10.12/0.5.0-finagle/thrift

--- a/build-support/bin/thrift/mac/10.13/0.7.0/thrift
+++ b/build-support/bin/thrift/mac/10.13/0.7.0/thrift
@@ -1,1 +1,1 @@
-build-support/bin/thrift/mac/10.12/0.7.0/thrift
+../../10.12/0.7.0/thrift

--- a/build-support/bin/thrift/mac/10.13/0.9.1/thrift
+++ b/build-support/bin/thrift/mac/10.13/0.9.1/thrift
@@ -1,1 +1,1 @@
-build-support/bin/thrift/mac/10.12/0.9.1/thrift
+../../10.12/0.9.1/thrift

--- a/build-support/bin/thrift/mac/10.13/0.9.2/thrift
+++ b/build-support/bin/thrift/mac/10.13/0.9.2/thrift
@@ -1,1 +1,1 @@
-build-support/bin/thrift/mac/10.12/0.9.2/thrift
+../../10.12/0.9.2/thrift

--- a/build-support/bin/thrift/mac/10.13/0.9.3/thrift
+++ b/build-support/bin/thrift/mac/10.13/0.9.3/thrift
@@ -1,1 +1,1 @@
-build-support/bin/thrift/mac/10.12/0.9.3/thrift
+../../10.12/0.9.3/thrift

--- a/build-support/bin/watchman/mac/10.13/4.5.0/watchman
+++ b/build-support/bin/watchman/mac/10.13/4.5.0/watchman
@@ -1,1 +1,1 @@
-build-support/bin/watchman/mac/10.12/4.5.0/watchman
+../../10.12/4.5.0/watchman

--- a/build-support/bin/watchman/mac/10.13/4.9.0/watchman
+++ b/build-support/bin/watchman/mac/10.13/4.9.0/watchman
@@ -1,1 +1,1 @@
-build-support/bin/watchman/mac/10.12/4.9.0/watchman
+../../10.12/4.9.0/watchman

--- a/build-support/bin/yarnpkg/mac/10.13/v0.19.1/yarnpkg.tar.gz
+++ b/build-support/bin/yarnpkg/mac/10.13/v0.19.1/yarnpkg.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/yarnpkg/mac/10.12/v0.19.1/yarnpkg.tar.gz
+../../10.12/v0.19.1/yarnpkg.tar.gz

--- a/build-support/bin/yarnpkg/mac/10.13/v0.20.0/yarnpkg.tar.gz
+++ b/build-support/bin/yarnpkg/mac/10.13/v0.20.0/yarnpkg.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/yarnpkg/mac/10.12/v0.20.0/yarnpkg.tar.gz
+../../10.12/v0.20.0/yarnpkg.tar.gz

--- a/build-support/bin/yarnpkg/mac/10.13/v0.21.3/yarnpkg.tar.gz
+++ b/build-support/bin/yarnpkg/mac/10.13/v0.21.3/yarnpkg.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/yarnpkg/mac/10.12/v0.21.3/yarnpkg.tar.gz
+../../10.12/v0.21.3/yarnpkg.tar.gz

--- a/build-support/bin/yarnpkg/mac/10.13/v0.23.3/yarnpkg.tar.gz
+++ b/build-support/bin/yarnpkg/mac/10.13/v0.23.3/yarnpkg.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/yarnpkg/mac/10.12/v0.23.3/yarnpkg.tar.gz
+../../10.12/v0.23.3/yarnpkg.tar.gz

--- a/build-support/bin/yarnpkg/mac/10.13/v0.27.5/yarnpkg.tar.gz
+++ b/build-support/bin/yarnpkg/mac/10.13/v0.27.5/yarnpkg.tar.gz
@@ -1,1 +1,1 @@
-build-support/bin/yarnpkg/mac/10.12/v0.27.5/yarnpkg.tar.gz
+../../10.12/v0.27.5/yarnpkg.tar.gz


### PR DESCRIPTION
Done with:
```bash
$ find $PWD/build-support/bin -wholename "*/mac/10.12/*" -type f | {
  while read binary
  do
    newbin=${binary/\/10.12\//\/10.13\/}

    binary=$(basename ${newbin})
    newdir=$(dirname ${newbin})
    version=$(basename ${newdir})

    rm -rf ${newdir}
    mkdir -p ${newdir}
    cd ${newdir}
    ln -s ../../10.12/${version}/${binary}
  done
}
```

Fixes #35