### PR TITLE
Replace protoc with one which was build on wheezy

### DIFF
--- a/build-protobuf-3.1.0.sh
+++ b/build-protobuf-3.1.0.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 # NOTE: Ensure you have autoconf, automake and libtool installed via
-        homebrew/apt-get/whatever.
+#       homebrew/apt-get/whatever.
  
 curl -L -O https://github.com/google/protobuf/archive/v3.1.0.tar.gz && \
 rm -rf protobuf-3.1.0 && \
-tar -xjf v3.1.0.tar.gz && \
+tar -xzf v3.1.0.tar.gz && \
 cd protobuf-3.1.0 && \
 ./autogen.sh && \
-./configure && \
+./configure --disable-shared && \
 make


### PR DESCRIPTION
The current one requires a newer libc than wheezy has.

Also, fix up the compile script.