### PR TITLE
Synchronize docker instructions with pantsbuild/pants

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ linux
 Requires [docker](https://www.docker.com/)
 
 + Change directories to the root of this repository.
-+ `docker run -v "$(pwd):/pantsbuild-binaries" -rm -it --entrypoint /bin/bash python:2.7.13-wheezy && cd /pantsbuild-binaries` to pop yourself in a controlled image back at this repo's root
++ `docker run -v "$(pwd):/pantsbuild-binaries" --rm -it --entrypoint /bin/bash pantsbuild/centos6:latest && cd /pantsbuild-binaries` to pop yourself in a controlled image back at this repo's root
 + Run the build-\*.sh script corresponding to the binary you wish to build
 + Manually move the binary from the build tree to its home in build-support/...
 


### PR DESCRIPTION
Recommend the pantsbuild centos6 image, rather than wheezy (which has a slightly newer libc).