### PR TITLE
Add go download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ binaries
 
 A home for scripts that build pants static binaries.
 
+
+Supported Platforms
+===================
+
+As of Spring 2018, binaries are no longer being published for i386 nor macOS versions prior to 10.8.
+Binaries for Linux x86_64 and macOS 10.8+ are generally published.
+
 workflow
 ========
 

--- a/build-support/bin/go/linux/x86_64/1.10/build.sh
+++ b/build-support/bin/go/linux/x86_64/1.10/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/linux/x86_64/1.9.4/build.sh
+++ b/build-support/bin/go/linux/x86_64/1.9.4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.10/1.10/build.sh
+++ b/build-support/bin/go/mac/10.10/1.10/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.10/1.9.4/build.sh
+++ b/build-support/bin/go/mac/10.10/1.9.4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.4.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.11/1.10/build.sh
+++ b/build-support/bin/go/mac/10.11/1.10/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.11/1.9.4/build.sh
+++ b/build-support/bin/go/mac/10.11/1.9.4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.4.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.12/1.10/build.sh
+++ b/build-support/bin/go/mac/10.12/1.10/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.12/1.9.4/build.sh
+++ b/build-support/bin/go/mac/10.12/1.9.4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.4.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.13/1.10/build.sh
+++ b/build-support/bin/go/mac/10.13/1.10/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.13/1.9.4/build.sh
+++ b/build-support/bin/go/mac/10.13/1.9.4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.4.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.8/1.10/build.sh
+++ b/build-support/bin/go/mac/10.8/1.10/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.8/1.9.4/build.sh
+++ b/build-support/bin/go/mac/10.8/1.9.4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.4.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.9/1.10/build.sh
+++ b/build-support/bin/go/mac/10.9/1.10/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.9/1.9.4/build.sh
+++ b/build-support/bin/go/mac/10.9/1.9.4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.4.darwin-amd64.tar.gz -o go.tar.gz

--- a/gen-go-build.py
+++ b/gen-go-build.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+
+# Helper for creating Go build.sh files. This script will create a default build.sh file
+# for Go/macOS/Linux versions listed below, unless the directory already exists. If a custom
+# build.sh script is needed, just create it and this helper will ignore it going forward.
+
+import os
+from textwrap import dedent
+
+go_versions = [
+    '1.9.4',
+    '1.10',
+]
+
+mac_versions = [
+    '10.8',
+    '10.9',
+    '10.10',
+    '10.11',
+    '10.12',
+    '10.13',
+]
+
+tmpl = dedent("""\
+    #!/bin/bash
+    set -o xtrace
+    curl https://storage.googleapis.com/golang/go{go_version}.{arch}.tar.gz -o go.tar.gz
+    """)
+
+def maybe_gen(dir, go_version, arch):
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+        filename = os.path.join(dir, 'build.sh')
+        with open(filename, 'w') as fh:
+            fh.write(tmpl.format(go_version=go_version, arch=arch))
+        os.chmod(filename, 0755)
+
+def mac():
+    for mac_version in mac_versions:
+        for go_version in go_versions:
+            dir = 'build-support/bin/go/mac/%s/%s' % (mac_version, go_version)
+            maybe_gen(dir, go_version, 'darwin-amd64')
+
+def x86_64():
+    for go_version in go_versions:
+        dir = 'build-support/bin/go/linux/x86_64/%s' % go_version
+        maybe_gen(dir, go_version, 'linux-amd64')
+
+mac()
+x86_64()


### PR DESCRIPTION
Go publishes pre-built artifacts for both macOS and Linux, simplifying
the pants mirroring of these artifacts. Here we add a script that has a
list of which architecture, macOS versions, and Go versions to download
and setup symlinks for. Running this script localy will setup the
environment for syncing Go binaries to s3.