### PR TITLE
Set default versions for to build Nodejs 8.11.1 and Yarnpkg 1.6.0

### DIFF
--- a/build-node.sh
+++ b/build-node.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=${1-:"v8.11.1"}
+VERSION=${1:-"v8.11.1"}
 
 CURRENT_MAC_VERSION="10.13"
 

--- a/build-node.sh
+++ b/build-node.sh
@@ -1,12 +1,10 @@
 #!/bin/sh
 
-VERSION=${1-:"v8.6.0"}
+VERSION=${1-:"v8.11.1"}
 
 CURRENT_MAC_VERSION="10.13"
 
 ADDITIONAL_MAC_VERSIONS=(
-  10.6
-  10.7
   10.8
   10.9
   10.10

--- a/build-yarnpkg.sh
+++ b/build-yarnpkg.sh
@@ -1,12 +1,10 @@
 #!/bin/bash -exuo pipefail
 
-VERSION=${1:-"v1.2.0"}
+VERSION=${1:-"v1.6.0"}
 
 CURRENT_MAC_VERSION="10.13"
 
 ADDITIONAL_MAC_VERSIONS=(
-  10.6
-  10.7
   10.8
   10.9
   10.10


### PR DESCRIPTION
Summary:
- Remove building for Mac versions < 10.8.
- Fix a bug in the build-node.sh script where the default version was incorrectly set with a '-' character.

Tested:
```docker run -v "$(pwd):/pantsbuild-binaries" -w '/pantsbuild-binaries' --rm -it pantsbuild/centos6:latest /bin/bash
./build-node.sh & ./build-yarnpkg.sh
```