### PR TITLE
add this_file_dir before '..' and 'lib' in the wrapper library path for xz

### DIFF
--- a/build-support/bin/xz/linux/x86_64/5.2.4-3/build-xz.sh
+++ b/build-support/bin/xz/linux/x86_64/5.2.4-3/build-xz.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+source "$(git rev-parse --show-toplevel)/utils.v1.bash"
+
+set_strict_mode
+
+XZ_WRAPPER_SCRIPT="$(get_existing_absolute_path ./xz.py)"
+
+function wrap_xz_lib_path_then_package {
+  mv bin/xz{,-real}
+
+  cp "$XZ_WRAPPER_SCRIPT" bin/xz
+
+  chmod +x bin/xz
+
+  create_gz_package 'xz'
+}
+
+function package_xz {
+  local -r installed_dir_abs="$1"
+
+  with_pushd "$installed_dir_abs" \
+             wrap_xz_lib_path_then_package
+}
+
+function fetch_extract_xz_source_release {
+  local -r archive_dirname="xz-${XZ_VERSION}"
+  local -r archive_filename="${archive_dirname}.tar.gz"
+  local -r release_url="https://tukaani.org/xz/${archive_filename}"
+
+  local -r downloaded_archive="$(curl_file_with_fail "$release_url" "$archive_filename")"
+  extract_for "$downloaded_archive" "$archive_dirname"
+}
+
+function build_xz {
+  local -r install_dir_abs="$1"
+
+  # --disable-rpath is necessary to make the xz package work "out of the box" -- otherwise at
+  # runtime it searches for a path in the filesystem of the VM that created it!
+  ./configure \
+    --disable-rpath \
+    --prefix="$install_dir_abs"
+
+  make "-j${MAKE_JOBS}"
+
+  make install
+}
+
+function fetch_build_xz {
+  local -r install_dir_abs="$(mkdirp_absolute_path 'xz-install')"
+
+  local -r xz_src_extracted_abs="$(fetch_extract_xz_source_release)"
+
+  with_pushd >&2 "$xz_src_extracted_abs" \
+                 build_xz "$install_dir_abs"
+
+  package_xz "$install_dir_abs"
+}
+
+readonly TARGET_PLATFORM="$1" XZ_VERSION="$2"
+
+readonly MAKE_JOBS="${MAKE_JOBS:-2}"
+
+case "$TARGET_PLATFORM" in
+  osx)
+    with_pushd "$(mkdirp_absolute_path "xz-${XZ_VERSION}-osx")" \
+               fetch_build_xz
+    ;;
+  linux)
+    with_pushd "$(mkdirp_absolute_path "xz-${XZ_VERSION}-linux")" \
+               fetch_build_xz
+    ;;
+  *)
+    die "xz does not support building for '${TARGET_PLATFORM}'"
+    ;;
+esac

--- a/build-support/bin/xz/linux/x86_64/5.2.4-3/build.sh
+++ b/build-support/bin/xz/linux/x86_64/5.2.4-3/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+readonly result="$(./build-xz.sh linux 5.2.4)"
+
+cp "$result" ./xz.tar.gz

--- a/build-support/bin/xz/linux/x86_64/5.2.4-3/xz.py
+++ b/build-support/bin/xz/linux/x86_64/5.2.4-3/xz.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import subprocess
+import sys
+
+argv = sys.argv
+
+this_file_dir = os.path.dirname(__file__)
+
+xz_executable = os.path.realpath(os.path.join(this_file_dir, 'xz-real'))
+
+xz_lib_dir = os.path.realpath(os.path.join(this_file_dir, '..', 'lib'))
+
+platform = os.uname()[0]
+
+if platform == 'Darwin':
+  env_var = 'DYLD_LIBRARY_PATH'
+elif platform == 'Linux':
+  env_var = 'LD_LIBRARY_PATH'
+else:
+  raise ValueError('Unrecognized platform: {}.'.format(platform))
+
+prev_lib_path = os.environ.get(env_var, '')
+lib_path_entries = [s for s in prev_lib_path.split(':') if s != '']
+lib_path_ours_first = [xz_lib_dir] + lib_path_entries
+
+new_env = os.environ.copy()
+
+new_env[env_var] = ':'.join(lib_path_ours_first)
+
+# Inherit the standard fds, close any extra we may have opened.
+rc = subprocess.call(sys.argv, executable=xz_executable, env=new_env, close_fds=True)
+sys.exit(rc)

--- a/build-support/bin/xz/mac/10.13/5.2.4-3/build-xz.sh
+++ b/build-support/bin/xz/mac/10.13/5.2.4-3/build-xz.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+source "$(git rev-parse --show-toplevel)/utils.v1.bash"
+
+set_strict_mode
+
+XZ_WRAPPER_SCRIPT="$(get_existing_absolute_path ./xz.py)"
+
+function wrap_xz_lib_path_then_package {
+  mv bin/xz{,-real}
+
+  cp "$XZ_WRAPPER_SCRIPT" bin/xz
+
+  chmod +x bin/xz
+
+  create_gz_package 'xz'
+}
+
+function package_xz {
+  local -r installed_dir_abs="$1"
+
+  with_pushd "$installed_dir_abs" \
+             wrap_xz_lib_path_then_package
+}
+
+function fetch_extract_xz_source_release {
+  local -r archive_dirname="xz-${XZ_VERSION}"
+  local -r archive_filename="${archive_dirname}.tar.gz"
+  local -r release_url="https://tukaani.org/xz/${archive_filename}"
+
+  local -r downloaded_archive="$(curl_file_with_fail "$release_url" "$archive_filename")"
+  extract_for "$downloaded_archive" "$archive_dirname"
+}
+
+function build_xz {
+  local -r install_dir_abs="$1"
+
+  # --disable-rpath is necessary to make the xz package work "out of the box" -- otherwise at
+  # runtime it searches for a path in the filesystem of the VM that created it!
+  ./configure \
+    --disable-rpath \
+    --prefix="$install_dir_abs"
+
+  make "-j${MAKE_JOBS}"
+
+  make install
+}
+
+function fetch_build_xz {
+  local -r install_dir_abs="$(mkdirp_absolute_path 'xz-install')"
+
+  local -r xz_src_extracted_abs="$(fetch_extract_xz_source_release)"
+
+  with_pushd >&2 "$xz_src_extracted_abs" \
+                 build_xz "$install_dir_abs"
+
+  package_xz "$install_dir_abs"
+}
+
+readonly TARGET_PLATFORM="$1" XZ_VERSION="$2"
+
+readonly MAKE_JOBS="${MAKE_JOBS:-2}"
+
+case "$TARGET_PLATFORM" in
+  osx)
+    with_pushd "$(mkdirp_absolute_path "xz-${XZ_VERSION}-osx")" \
+               fetch_build_xz
+    ;;
+  linux)
+    with_pushd "$(mkdirp_absolute_path "xz-${XZ_VERSION}-linux")" \
+               fetch_build_xz
+    ;;
+  *)
+    die "xz does not support building for '${TARGET_PLATFORM}'"
+    ;;
+esac

--- a/build-support/bin/xz/mac/10.13/5.2.4-3/build.sh
+++ b/build-support/bin/xz/mac/10.13/5.2.4-3/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+readonly result="$(./build-xz.sh linux 5.2.4)"
+
+cp "$result" ./xz.tar.gz

--- a/build-support/bin/xz/mac/10.13/5.2.4-3/xz.py
+++ b/build-support/bin/xz/mac/10.13/5.2.4-3/xz.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import subprocess
+import sys
+
+argv = sys.argv
+
+this_file_dir = os.path.dirname(__file__)
+
+xz_executable = os.path.realpath(os.path.join(this_file_dir, 'xz-real'))
+
+xz_lib_dir = os.path.realpath(os.path.join(this_file_dir, '..', 'lib'))
+
+platform = os.uname()[0]
+
+if platform == 'Darwin':
+  env_var = 'DYLD_LIBRARY_PATH'
+elif platform == 'Linux':
+  env_var = 'LD_LIBRARY_PATH'
+else:
+  raise ValueError('Unrecognized platform: {}.'.format(platform))
+
+prev_lib_path = os.environ.get(env_var, '')
+lib_path_entries = [s for s in prev_lib_path.split(':') if s != '']
+lib_path_ours_first = [xz_lib_dir] + lib_path_entries
+
+new_env = os.environ.copy()
+
+new_env[env_var] = ':'.join(lib_path_ours_first)
+
+# Inherit the standard fds, close any extra we may have opened.
+rc = subprocess.call(sys.argv, executable=xz_executable, env=new_env, close_fds=True)
+sys.exit(rc)


### PR DESCRIPTION
Our `xz` wrapper script was trying to add `../lib` relative to the process cwd, not the directory containing our wrapper script. This fixes that, in yet another bumped version `5.2.4-3`.

I have not been able to reproduce the [failing behavior on Travis that makes all this necessary](https://travis-ci.org/pantsbuild/pants/jobs/391464488), but this is what should have been done in #72. Sorry for the haste!