### PR TITLE
Add coursier build script

### DIFF
--- a/build-support/bin/coursier/pants_release_1.5.x/build-coursier.sh
+++ b/build-support/bin/coursier/pants_release_1.5.x/build-coursier.sh
@@ -4,7 +4,6 @@
 VERSION=$1
 
 DEST_JAR_NAME="coursier-cli-${VERSION}.jar"
-DEST_DIR="build-support/bin/coursier/${VERSION}/"
 
 TEMPDIR="/tmp/coursier"
 rm -rf ${TEMPDIR} && \
@@ -14,5 +13,4 @@ pushd ${TEMPDIR} && \
 git checkout -f ${VERSION} && \
 ./pants binary cli/src/main/scala-2.12:coursier-cli && \
 popd && \
-mkdir -p ${DEST_DIR} && \
 mv ${TEMPDIR}/dist/coursier-cli.jar ${DEST_JAR_NAME}

--- a/build-support/bin/coursier/pants_release_1.5.x/build-coursier.sh
+++ b/build-support/bin/coursier/pants_release_1.5.x/build-coursier.sh
@@ -6,9 +6,11 @@ VERSION=$1
 DEST_JAR_NAME="coursier-cli-${VERSION}.jar"
 DEST_DIR="build-support/bin/coursier/${VERSION}/"
 
-rm -rf coursier && \
-git clone https://github.com/coursier/coursier.git && \
-pushd coursier && \
+TEMPDIR="/tmp/coursier"
+rm -rf ${TEMPDIR} && \
+mkdir -p ${TEMPDIR} && \
+git clone https://github.com/coursier/coursier.git ${TEMPDIR} && \
+pushd ${TEMPDIR} && \
 git checkout -f ${VERSION} && \
 ./pants binary cli/src/main/scala-2.12:coursier-cli && \
 popd && \

--- a/build-support/bin/coursier/pants_release_1.5.x/build-coursier.sh
+++ b/build-support/bin/coursier/pants_release_1.5.x/build-coursier.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Also the tag
+VERSION=$1
+
+DEST_JAR_NAME="coursier-cli-${VERSION}.jar"
+DEST_DIR="build-support/bin/coursier/${VERSION}/"
+
+rm -rf coursier && \
+git clone https://github.com/coursier/coursier.git && \
+pushd coursier && \
+git checkout -f ${VERSION} && \
+./pants binary cli/src/main/scala-2.12:coursier-cli && \
+popd && \
+mkdir -p ${DEST_DIR} && \
+mv coursier/dist/coursier-cli.jar "${DEST_DIR}/${DEST_JAR_NAME}"

--- a/build-support/bin/coursier/pants_release_1.5.x/build-coursier.sh
+++ b/build-support/bin/coursier/pants_release_1.5.x/build-coursier.sh
@@ -15,4 +15,4 @@ git checkout -f ${VERSION} && \
 ./pants binary cli/src/main/scala-2.12:coursier-cli && \
 popd && \
 mkdir -p ${DEST_DIR} && \
-mv coursier/dist/coursier-cli.jar "${DEST_DIR}/${DEST_JAR_NAME}"
+mv ${TEMPDIR}/dist/coursier-cli.jar ${DEST_JAR_NAME}

--- a/build-support/bin/coursier/pants_release_1.5.x/build.sh
+++ b/build-support/bin/coursier/pants_release_1.5.x/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./build-coursier.sh "pants_release_1.5.x"

--- a/build-support/bin/coursier/pants_release_1.5.x/build.sh
+++ b/build-support/bin/coursier/pants_release_1.5.x/build.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 ./build-coursier.sh "pants_release_1.5.x"


### PR DESCRIPTION
So coursier jar can exist in binaries.pantsbuild.org instead of being on dropbox. 