### PR TITLE
Add updated go versions to pants binaries

### DIFF
--- a/build-support/bin/go/linux/x86_64/1.10.8/build.sh
+++ b/build-support/bin/go/linux/x86_64/1.10.8/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.8.linux-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/linux/x86_64/1.11.5/build.sh
+++ b/build-support/bin/go/linux/x86_64/1.11.5/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.11.5.linux-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/linux/x86_64/1.12/build.sh
+++ b/build-support/bin/go/linux/x86_64/1.12/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/linux/x86_64/1.9.7/build.sh
+++ b/build-support/bin/go/linux/x86_64/1.9.7/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.7.linux-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.10/1.10.8/build.sh
+++ b/build-support/bin/go/mac/10.10/1.10.8/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.8.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.10/1.11.5/build.sh
+++ b/build-support/bin/go/mac/10.10/1.11.5/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.11.5.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.10/1.12/build.sh
+++ b/build-support/bin/go/mac/10.10/1.12/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.12.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.11/1.10.8/build.sh
+++ b/build-support/bin/go/mac/10.11/1.10.8/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.8.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.11/1.11.5/build.sh
+++ b/build-support/bin/go/mac/10.11/1.11.5/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.11.5.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.11/1.12/build.sh
+++ b/build-support/bin/go/mac/10.11/1.12/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.12.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.12/1.10.8/build.sh
+++ b/build-support/bin/go/mac/10.12/1.10.8/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.8.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.12/1.11.5/build.sh
+++ b/build-support/bin/go/mac/10.12/1.11.5/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.11.5.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.12/1.12/build.sh
+++ b/build-support/bin/go/mac/10.12/1.12/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.12.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.13/1.10.8/build.sh
+++ b/build-support/bin/go/mac/10.13/1.10.8/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.8.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.13/1.11.5/build.sh
+++ b/build-support/bin/go/mac/10.13/1.11.5/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.11.5.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.13/1.12/build.sh
+++ b/build-support/bin/go/mac/10.13/1.12/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.12.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.14/1.10.8/build.sh
+++ b/build-support/bin/go/mac/10.14/1.10.8/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.8.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.14/1.11.5/build.sh
+++ b/build-support/bin/go/mac/10.14/1.11.5/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.11.5.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.14/1.12/build.sh
+++ b/build-support/bin/go/mac/10.14/1.12/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.12.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.8/1.10.8/build.sh
+++ b/build-support/bin/go/mac/10.8/1.10.8/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.8.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.8/1.9.7/build.sh
+++ b/build-support/bin/go/mac/10.8/1.9.7/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.9.7.darwin-amd64.tar.gz -o go.tar.gz

--- a/build-support/bin/go/mac/10.9/1.10.8/build.sh
+++ b/build-support/bin/go/mac/10.9/1.10.8/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o xtrace
+curl https://storage.googleapis.com/golang/go1.10.8.darwin-amd64.tar.gz -o go.tar.gz

--- a/gen-go-build.py
+++ b/gen-go-build.py
@@ -39,8 +39,8 @@ def maybe_gen(dir, go_version, arch):
         os.chmod(filename, 0755)
 
 def mac():
-    for mac_version, go_versions in mac_versions.items():
-        for go_version in go_versions:
+    for mac_version, mac_go_versions in mac_versions.items():
+        for go_version in mac_go_versions:
             dir = 'build-support/bin/go/mac/%s/%s' % (mac_version, go_version)
             maybe_gen(dir, go_version, 'darwin-amd64')
 

--- a/gen-go-build.py
+++ b/gen-go-build.py
@@ -39,7 +39,7 @@ def maybe_gen(dir, go_version, arch):
         os.chmod(filename, 0755)
 
 def mac():
-    for mac_version, go_versions in mac_versions:
+    for mac_version, go_versions in mac_versions.items():
         for go_version in go_versions:
             dir = 'build-support/bin/go/mac/%s/%s' % (mac_version, go_version)
             maybe_gen(dir, go_version, 'darwin-amd64')

--- a/gen-go-build.py
+++ b/gen-go-build.py
@@ -8,18 +8,21 @@ import os
 from textwrap import dedent
 
 go_versions = [
-    '1.9.4',
-    '1.10',
+    '1.9.7',
+    '1.10.8',
+    '1.11.5',
+    '1.12',
 ]
 
-mac_versions = [
-    '10.8',
-    '10.9',
-    '10.10',
-    '10.11',
-    '10.12',
-    '10.13',
-]
+mac_versions = {
+    '10.8': ['1.9.7', '1.10.8'],
+    '10.9': ['1.10.8'],
+    '10.10': ['1.10.8', '1.11.5', '1.12'],
+    '10.11': ['1.10.8', '1.11.5', '1.12'],
+    '10.12': ['1.10.8', '1.11.5', '1.12'],
+    '10.13': ['1.10.8', '1.11.5', '1.12'],
+    '10.14': ['1.10.8', '1.11.5', '1.12'],
+}
 
 tmpl = dedent("""\
     #!/bin/bash
@@ -36,7 +39,7 @@ def maybe_gen(dir, go_version, arch):
         os.chmod(filename, 0755)
 
 def mac():
-    for mac_version in mac_versions:
+    for mac_version, go_versions in mac_versions:
         for go_version in go_versions:
             dir = 'build-support/bin/go/mac/%s/%s' % (mac_version, go_version)
             maybe_gen(dir, go_version, 'darwin-amd64')


### PR DESCRIPTION
I expanded the mac_versions into a map to encode the OSX min version requirements of the latest builds of go. I didn't execute the script because it's taking quite a long time to clone the repository.