### PR TITLE
Add cloc 1.80

### DIFF
--- a/build-support/bin/cloc/1.80/build-cloc-1.80.sh
+++ b/build-support/bin/cloc/1.80/build-cloc-1.80.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+curl -L -o cloc https://github.com/AlDanial/cloc/releases/download/1.80/cloc-1.80.pl
+chmod ugo+x cloc


### PR DESCRIPTION
The current version of cloc (version 1.82) has a bug where the --ignored
flag is not working properly ( https://github.com/AlDanial/cloc/issues/401 ).
The pants test for the cloc goal tests this behavior, so as long as this
bug is not fixed upstream, pants will fail this test. I've confirmed
that version 1.80 of cloc does not have this bug, so we should be able
to use it until upstream cloc fixes the bug in a new verson.